### PR TITLE
Replace the 'Atom' tuple with a record.

### DIFF
--- a/CoMD-Chapel-Opt/forceeam.chpl
+++ b/CoMD-Chapel-Opt/forceeam.chpl
@@ -42,7 +42,7 @@ class InterpolationObject {
     // reset r to fractional distance
     r = r - floor(r);
 
-    var v : (real, real, real, real);
+    var v : 4*real;
     for i in -1..2 do v(i+2) = values(ii+i);
 
     const g1 : real = v(3) - v(1);
@@ -369,7 +369,7 @@ if useChplVis then tagVdebug("computeEAMForce");
             for i in 1..box(1) {
               var fij:real3, pij:real, rij:real;
               for j in 1..nBox(1) {
-                force.compute1(box(2)(i)(5), nBox(2)(j)(5), fij, pij, rij);
+                force.compute1(box(2)(i).r, nBox(2)(j).r, fij, pij, rij);
               }
               f(i) -= fij;
               pe(i) += pij;
@@ -405,7 +405,7 @@ if useChplVis then tagVdebug("computeEAMForce");
             for i in 1..box(1) {
               var fij:real3;
               for j in 1..nBox(1) {
-                force.compute2(box(2)(i)(5), nBox(2)(j)(5), dfEmbed(i)+nDfEmbed(j), fij);
+                force.compute2(box(2)(i).r, nBox(2)(j).r, dfEmbed(i)+nDfEmbed(j), fij);
               }
               f(i) -= fij;
             }
@@ -440,7 +440,7 @@ local {
             for i in 1..box(1) {
               var fij:real3, pij:real, rij:real;
               for j in 1..nBox(1) {
-                force.compute1(box(2)(i)(5), nBox(2)(j)(5), fij, pij, rij);
+                force.compute1(box(2)(i).r, nBox(2)(j).r, fij, pij, rij);
               }
               f(i) -= fij;
               pe(i) += pij;
@@ -478,7 +478,7 @@ local {
             for i in 1..box(1) {
               var fij:real3;
               for j in 1..nBox(1) {
-                force.compute2(box(2)(i)(5), nBox(2)(j)(5), dfEmbed(i)+nDfEmbed(j), fij);
+                force.compute2(box(2)(i).r, nBox(2)(j).r, dfEmbed(i)+nDfEmbed(j), fij);
               }
               f(i) -= fij;
             }

--- a/CoMD-Chapel-Opt/forcelj.chpl
+++ b/CoMD-Chapel-Opt/forcelj.chpl
@@ -67,7 +67,7 @@ if useChplVis then tagVdebug("computeLJForce");
             for i in 1..box(1) {
               var fi:real3, pi:real;
               for j in 1..nBox(1) {
-                force.compute(box(2)(i)(5), nBox(2)(j)(5), fi, pi);
+                force.compute(box(2)(i).r, nBox(2)(j).r, fi, pi);
               }
               f(i)  += fi;
               pe(i) += pi;
@@ -98,7 +98,7 @@ local {
             for i in 1..box(1) {
               var fi:real3, pi:real;
               for j in 1..nBox(1) {
-                force.compute(box(2)(i)(5), nBox(2)(j)(5), fi, pi);
+                force.compute(box(2)(i).r, nBox(2)(j).r, fi, pi);
               }
               f(i)  += fi;
               pe(i) += pi;

--- a/CoMD-Chapel-Opt/setup.chpl
+++ b/CoMD-Chapel-Opt/setup.chpl
@@ -12,25 +12,20 @@ var boxSize   : real3; // size of link cell
 var numBoxes  : int3;  // number of link cells
 
 // atom
-/*
 record Atom {
   var gid  : int(32);
   var mass : real;
   var species : int(32);
-  var name : string;
   var r : real3;
   var v : real3;
 }
-*/
-
-type Atom = (int(32), real, int(32), string, real3, real3);
 
 inline proc >(const ref a : Atom, const ref b : Atom) : bool {
-  return a(1) > b(1);
+  return a.gid > b.gid;
 }
 
 inline proc <(const ref a : Atom, const ref b : Atom) : bool {
-  return a(1) < b(1);
+  return a.gid < b.gid;
 }
 
 inline proc <=(const ref a : Atom, const ref b : Atom) : bool {


### PR DESCRIPTION
The 'name' string field in the 'Atom' was likely preventing bulk
transfers. Removing that field should greatly improve performance.
I was also able to convert the 'Atom' tuple to a record without
losing performance, and I think it's much better from an elegance
perspective.

Also cleans up the 'haloExchange' step to rely on array assignment for
the bulk transfer instead of calling underlying chapel functions.
