### PR TITLE
Implement a pack/unpack haloExchange step.

### DIFF
--- a/CoMD-Chapel-Opt/setup.chpl
+++ b/CoMD-Chapel-Opt/setup.chpl
@@ -67,6 +67,10 @@ class Domain {
   var neighs         : [neighDom] int3;                    // neighbors on each face (xm, xp, ym, yp, zm, zp)
   var temps1         : [neighDom] FaceArr;                 // temp arrays for each face (xm, xp, ym, yp, zm, zp)
   var temps2         : [neighDom] FaceArr;                 // temp arrays for each face (xm, xp, ym, yp, zm, zp)
+  var bufDom         : domain(1);                          // Domain for buffer size, set during grid initialization
+  var recvBuf,                                             // Each face gets a receive buffer for haloExchange
+      packBuf        : [neighDom] [bufDom] Atom;           // Each face gets a local packing buffer for haloExchange
+  var recvSize       : [neighDom] int;
   var srcSlice       : [neighDom] domain(3);               // src (remote) slice for each face (xm, xp, ym, yp, zm, zp)
   var destSlice      : [neighDom] domain(3);               // dest (local) slice for each face (xm, xp, ym, yp, zm, zp)
   var pbc            : [neighDom] real3;                   // periodic boundary shift for each face (xm, xp, ym, yp, zm, zp)


### PR DESCRIPTION
The MPI+OpenMP reference version packs atoms into a buffer and sends that
across to the appropriate rank. By implementing this in Chapel, I tend to see
better performance.

Prior to this commit, the haloExchange did a GET from a remote locale to the
current locale. This commit does a PUT from the current locale to the target
locale. I think this makes it easier to pack up the buffer and minimize
communication.

Removes 'inline' from several procedures. I was finding it difficult to read
the generated C code. Removing the inline didn't appear to impact performance.

I think there also might be a way to parallelize the packing and unpacking, but that may cause overhead at smaller problem sizes. I'll leave that as future work.
