### PR TITLE
Replace most tuples with record or arrays

### DIFF
--- a/CoMD-Chapel-Opt/Makefile
+++ b/CoMD-Chapel-Opt/Makefile
@@ -1,4 +1,4 @@
-CHPL_FLAGS= --fast -suseBulkTransferStride -sdataParTasksPerLocale=5 -sdefaultDoRADOpt=true -sdisableAliasedBulkTransfer=false --conditional-dynamic-dispatch-limit=2
+CHPL_FLAGS= --fast -suseBulkTransferStride -sdataParTasksPerLocale=5 -sdefaultDoRADOpt=true -sdisableAliasedBulkTransfer=false --conditional-dynamic-dispatch-limit=2 -snoRefCount
 #CHPL_FLAGS= --fast --cache-remote -snoRefCount -suseBulkTransferStride -sdataParTasksPerLocale=5 -sdefaultDoRADOpt=true -sdisableAliasedBulkTransfer=false --conditional-dynamic-dispatch-limit=2
 
 SAVE_C_CODE= --savec ./c_code

--- a/CoMD-Chapel-Opt/forceeam.chpl
+++ b/CoMD-Chapel-Opt/forceeam.chpl
@@ -67,14 +67,14 @@ type RList = MAXATOMS*real;
 
 class EAMFaceArr {
   var d : domain(3);
-  var a : [d] RList;
+  var a : [d] [1..MAXATOMS] real;
 }
 
 class EAMDomain {
   var localDom  : domain(3);
   var halo      = localDom.expand(1);
   var dfEmbed   : [halo] RList;
-  var rhoBar    : [localDom] RList;
+  var rhoBar    : [localDom] [1..MAXATOMS] real;
   var neighDom  : domain(1) = {1..6};
   var neighs    : [neighDom] int3;
   //TODO: This temporary buffer was introduced to eliminate a spike during initial 

--- a/CoMD-Chapel-Opt/forceeam.chpl
+++ b/CoMD-Chapel-Opt/forceeam.chpl
@@ -358,7 +358,7 @@ if useChplVis then tagVdebug("computeEAMForce");
         const force = MyDom.force : ForceEAM;
         const neighs = {-1..1, -1..1, -1..1};
         coforall (box, f, pe, dfEmbed, rhoBar, boxIdx) in zip(MyDom.cells[MyDom.localDom], MyDom.f, MyDom.pe, MyEAMDom.dfEmbed[MyDom.localDom], MyEAMDom.rhoBar[MyDom.localDom], MyDom.localDom) {
-          for i in 1..box(1) {
+          for i in 1..box.count {
             f(i)  = (0.0, 0.0, 0.0);
             pe(i) = 0.0;
             rhoBar(i) = 0.0;
@@ -366,10 +366,10 @@ if useChplVis then tagVdebug("computeEAMForce");
 
           for n in neighs {
             const ref nBox = MyDom.cells[boxIdx + n];
-            for i in 1..box(1) {
+            for i in 1..box.count {
               var fij:real3, pij:real, rij:real;
-              for j in 1..nBox(1) {
-                force.compute1(box(2)(i).r, nBox(2)(j).r, fij, pij, rij);
+              for j in 1..nBox.count {
+                force.compute1(box.atoms(i).r, nBox.atoms(j).r, fij, pij, rij);
               }
               f(i) -= fij;
               pe(i) += pij;
@@ -377,7 +377,7 @@ if useChplVis then tagVdebug("computeEAMForce");
             }
           }
 
-          for i in 1..box(1) {
+          for i in 1..box.count {
             var fEmbedTmp, dfEmbedTmp:real; force.fIO.interpolate(rhoBar(i), fEmbedTmp, dfEmbedTmp);
             dfEmbed(i) = dfEmbedTmp;
             pe(i) += fEmbedTmp;
@@ -402,10 +402,10 @@ if useChplVis then tagVdebug("computeEAMForce");
           for n in neighs {
             const ref nBox = MyDom.cells[boxIdx + n];
             const ref nDfEmbed = MyEAMDom.dfEmbed[boxIdx + n];
-            for i in 1..box(1) {
+            for i in 1..box.count {
               var fij:real3;
-              for j in 1..nBox(1) {
-                force.compute2(box(2)(i).r, nBox(2)(j).r, dfEmbed(i)+nDfEmbed(j), fij);
+              for j in 1..nBox.count {
+                force.compute2(box.atoms(i).r, nBox.atoms(j).r, dfEmbed(i)+nDfEmbed(j), fij);
               }
               f(i) -= fij;
             }
@@ -429,7 +429,7 @@ if useChplVis then tagVdebug("computeEAMForce");
 local {
         const neighs = {-1..1, -1..1, -1..1};
         coforall (box, f, pe, dfEmbed, rhoBar, boxIdx) in zip(MyDom.cells[MyDom.localDom], MyDom.f, MyDom.pe, MyEAMDom.dfEmbed[MyDom.localDom], MyEAMDom.rhoBar[MyDom.localDom], MyDom.localDom) {
-          for i in 1..box(1) {
+          for i in 1..box.count {
             f(i)  = (0.0, 0.0, 0.0);
             pe(i) = 0.0;
             rhoBar(i) = 0.0;
@@ -437,10 +437,10 @@ local {
 
           for n in neighs {
             const ref nBox = MyDom.cells[boxIdx + n];
-            for i in 1..box(1) {
+            for i in 1..box.count {
               var fij:real3, pij:real, rij:real;
-              for j in 1..nBox(1) {
-                force.compute1(box(2)(i).r, nBox(2)(j).r, fij, pij, rij);
+              for j in 1..nBox.count {
+                force.compute1(box.atoms(i).r, nBox.atoms(j).r, fij, pij, rij);
               }
               f(i) -= fij;
               pe(i) += pij;
@@ -448,7 +448,7 @@ local {
             }
           }
 
-          for i in 1..box(1) {
+          for i in 1..box.count {
             var fEmbedTmp, dfEmbedTmp:real; force.fIO.interpolate(rhoBar(i), fEmbedTmp, dfEmbedTmp);
             dfEmbed(i) = dfEmbedTmp;
             pe(i) += fEmbedTmp;
@@ -475,10 +475,10 @@ local {
           for n in neighs {
             const ref nBox = MyDom.cells[boxIdx + n];
             const ref nDfEmbed = MyEAMDom.dfEmbed[boxIdx + n];
-            for i in 1..box(1) {
+            for i in 1..box.count {
               var fij:real3;
-              for j in 1..nBox(1) {
-                force.compute2(box(2)(i).r, nBox(2)(j).r, dfEmbed(i)+nDfEmbed(j), fij);
+              for j in 1..nBox.count {
+                force.compute2(box.atoms(i).r, nBox.atoms(j).r, dfEmbed(i)+nDfEmbed(j), fij);
               }
               f(i) -= fij;
             }

--- a/CoMD-Chapel-Opt/forcelj.chpl
+++ b/CoMD-Chapel-Opt/forcelj.chpl
@@ -57,17 +57,17 @@ if useChplVis then tagVdebug("computeLJForce");
         const force = MyDom.force : ForceLJ;
         const neighs = {-1..1, -1..1, -1..1};
         coforall (box, f, pe, boxIdx) in zip(MyDom.cells[MyDom.localDom], MyDom.f, MyDom.pe, MyDom.localDom) {
-          for i in 1..box(1) {
+          for i in 1..box.count {
             f(i)  = (0.0, 0.0, 0.0);
             pe(i) = 0.0;
           }
 
           for n in neighs {
             const ref nBox = MyDom.cells[boxIdx + n];
-            for i in 1..box(1) {
+            for i in 1..box.count {
               var fi:real3, pi:real;
-              for j in 1..nBox(1) {
-                force.compute(box(2)(i).r, nBox(2)(j).r, fi, pi);
+              for j in 1..nBox.count {
+                force.compute(box.atoms(i).r, nBox.atoms(j).r, fi, pi);
               }
               f(i)  += fi;
               pe(i) += pi;
@@ -88,17 +88,17 @@ if useChplVis then tagVdebug("computeLJForce");
 local {
         const neighs = {-1..1, -1..1, -1..1};
         coforall (box, f, pe, boxIdx) in zip(MyDom.cells[MyDom.localDom], MyDom.f, MyDom.pe, MyDom.localDom) {
-          for i in 1..box(1) {
+          for i in 1..box.count {
             f(i)  = (0.0, 0.0, 0.0);
             pe(i) = 0.0;
           }
 
           for n in neighs {
             const ref nBox = MyDom.cells[boxIdx + n];
-            for i in 1..box(1) {
+            for i in 1..box.count {
               var fi:real3, pi:real;
-              for j in 1..nBox(1) {
-                force.compute(box(2)(i).r, nBox(2)(j).r, fi, pi);
+              for j in 1..nBox.count {
+                force.compute(box.atoms(i).r, nBox.atoms(j).r, fi, pi);
               }
               f(i)  += fi;
               pe(i) += pi;

--- a/CoMD-Chapel-Opt/setup.chpl
+++ b/CoMD-Chapel-Opt/setup.chpl
@@ -41,14 +41,10 @@ type FList = MAXATOMS*real3;
 type PList = MAXATOMS*real;
 
 // link cell
-/*
 record Box {
   var count : int(32);
   var atoms : AtomList;
 }
-*/
-
-type Box = (int(32), AtomList);
 
 class FaceArr {
   var d : domain(3);

--- a/CoMD-Chapel-Opt/setup.chpl
+++ b/CoMD-Chapel-Opt/setup.chpl
@@ -36,14 +36,10 @@ inline proc >=(const ref a : Atom, const ref b : Atom) : bool {
   return !(a < b);
 }
 
-type AtomList = MAXATOMS*Atom;
-type FList = MAXATOMS*real3;
-type PList = MAXATOMS*real;
-
 // link cell
 record Box {
   var count : int(32);
-  var atoms : AtomList;
+  var atoms : [1..MAXATOMS] Atom;
 }
 
 class FaceArr {
@@ -56,8 +52,8 @@ class Domain {
   var localDom       : domain(3);                          // local domain
   var halo           = localDom.expand(1);                 // expanded domain (local+halo)
   var cells          : [halo] Box;                         // cells in the expanded domain
-  var f              : [localDom] FList;                   // force per atom in local cells
-  var pe             : [localDom] PList;                   // potential energy per atom in local cells
+  var f              : [localDom] [1..MAXATOMS] real3;     // force per atom in local cells
+  var pe             : [localDom] [1..MAXATOMS] real;      // potential energy per atom in local cells
   var neighDom       : domain(1) = {1..6};                 // domain of neighbors on each face (xm, xp, ym, yp, zm, zp)
   var nM$, nP$       : sync bool;                          // sync updates to neighbors for each face pair (xm/xp, ym/yp, zm/zp)
   var neighs         : [neighDom] int3;                    // neighbors on each face (xm, xp, ym, yp, zm, zp)


### PR DESCRIPTION
I think that the only remaining tuple is the "RList" in forceeam.chpl. Before removing it, I think we would need to re-implement the packing/unpacking logic to take advantage of bulk transfers.
